### PR TITLE
修复pip部分依赖问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,25 @@
 FROM python:slim
+RUN echo \
+  deb http://mirrors.aliyun.com/debian/ buster main non-free contrib\
+  deb-src http://mirrors.aliyun.com/debian/ buster main non-free contrib\
+  deb http://mirrors.aliyun.com/debian-security buster/updates main\
+  deb-src http://mirrors.aliyun.com/debian-security buster/updates main\
+  deb http://mirrors.aliyun.com/debian/ buster-updates main non-free contrib\
+  deb-src http://mirrors.aliyun.com/debian/ buster-updates main non-free contrib\
+  deb http://mirrors.aliyun.com/debian/ buster-backports main non-free contrib\
+  deb-src http://mirrors.aliyun.com/debian/ buster-backports main non-free  contrib\
+  > /etc/apt/sources.list
 RUN apt-get update && \
     apt-get install git -y && \
-    apt-get clean
-RUN git clone https://github.com/iceyhexman/onlinetools.git /onlinetools
-WORKDIR /onlinetools
+		apt-get install libffi-dev && \
+		apt-get clean
+WORKDIR /root/.pip
+RUN echo \
+	[global]\
+	index-url = http://pypi.douban.com/simple\
+	> ~/.pip/pip.conf
+RUN git clone  https://github.com/HexChristmas/onlinetools /onlinetools
 RUN pip install -r requirements.txt && \
     rm -fr ~/.cache/pip
 EXPOSE 8000
-CMD ["python","/onlinetools/main.py"]
+CMD ["python","/onlinescan/main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,19 @@ RUN echo \
 RUN apt-get update && \
     apt-get install git -y && \
 		apt-get install libffi-dev && \
+    apt-get install python-gevent -y && \
 		apt-get clean
 WORKDIR /root/.pip
 RUN echo \
-	[global]\
-	index-url = http://pypi.douban.com/simple\
+	[global] \
+	index-url = http://pypi.douban.com/simple \
 	> ~/.pip/pip.conf
-RUN git clone  https://github.com/HexChristmas/onlinetools /onlinetools
+CMD ["export", "http_proxy=http://xx.xx.xx.xx:7890"]
+CMD ["export", "https_proxt=http://xx.xx.xx.xx:7890"]
+CMD ["export", "all_proxt=socks5://xx.xx.xx.xx:7891"]
+RUN git clone  https://github.com/iceyhexman/onlinetools.git /onlinetools
+WORKDIR /onlinetools
 RUN pip install -r requirements.txt && \
     rm -fr ~/.cache/pip
 EXPOSE 8000
-CMD ["python","/onlinescan/main.py"]
+CMD ["python","/onlinetools/main.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-gevent
 requests==2.20.0
 bs4==0.0.1
 redis==2.10.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+gevent
 requests==2.20.0
 bs4==0.0.1
 redis==2.10.6


### PR DESCRIPTION
由于您长时间未更新，导致`pip`以及`apt`的依赖有问题。
`pip`使用了豆瓣较稳定的源。
因为`git clone `十分慢的原因，在这里使用代理来加速。